### PR TITLE
Configurable ivoa.ObsCore table name

### DIFF
--- a/sia2/src/main/java/org/opencadc/sia2/AdqlQueryGenerator.java
+++ b/sia2/src/main/java/org/opencadc/sia2/AdqlQueryGenerator.java
@@ -90,15 +90,18 @@ public class AdqlQueryGenerator {
 
     private static Logger log = Logger.getLogger(AdqlQueryGenerator.class);
 
+    private String tableName;
     private Map<String, List<String>> queryParams;
 
     /**
      * The input SIA query parameters as structured by the ParamExtractor in cadcDALI.
      *
      * @param query query input parameters
+     * @param tableName ivoa.ObsCore table name
      * @see ca.nrc.cadc.dali.ParamExtractor
      */
-    public AdqlQueryGenerator(Map<String, List<String>> query) {
+    public AdqlQueryGenerator(Map<String, List<String>> query, String tableName) {
+        this.tableName = tableName;
         this.queryParams = query;
     }
 
@@ -118,7 +121,9 @@ public class AdqlQueryGenerator {
 
     protected String getQuery() {
         StringBuilder query = new StringBuilder();
-        query.append("SELECT * FROM ivoa.ObsCore WHERE dataproduct_type IN ( 'image', 'cube' )");
+        query.append("SELECT * FROM ");
+        query.append(tableName);
+        query.append(" WHERE dataproduct_type IN ( 'image', 'cube' )");
 
         SiaParamValidator sia = new SiaParamValidator();
         List<Shape> pos = sia.validatePOS(queryParams);

--- a/sia2/src/main/java/org/opencadc/sia2/SiaConfig.java
+++ b/sia2/src/main/java/org/opencadc/sia2/SiaConfig.java
@@ -92,8 +92,10 @@ public class SiaConfig {
     
     private static final String BASE_KEY = "org.opencadc.sia2";
     private static final String QUERY_KEY = BASE_KEY + ".queryService";
+    private static final String TABLE_KEY = BASE_KEY + ".table";
     
     private final URI queryService;
+    private final String tableName;
     
     public SiaConfig() {
         StringBuilder sb = new StringBuilder();
@@ -119,11 +121,22 @@ public class SiaConfig {
                 throw new InvalidConfigException("invalid config: " + sb.toString());
             }
             this.queryService = qsURI;
+
+	    String tn = props.getFirstPropertyValue(TABLE_KEY);
+	    if (tn == null) {
+		this.tableName = "ivoa.ObsCore";
+	    } else {
+                this.tableName = tn;
+	    }
         } catch (InvalidConfigException ex) {
             throw ex;
         }
     }
     
+    public String getTableName() {
+	return tableName;
+    }
+
     public URI getQueryService() {
         return queryService;
     }

--- a/sia2/src/main/java/org/opencadc/sia2/SiaRunner.java
+++ b/sia2/src/main/java/org/opencadc/sia2/SiaRunner.java
@@ -162,11 +162,12 @@ public class SiaRunner implements JobRunner {
             mv.setMaxValue(MAX_MAXREC);
             Integer maxrec = mv.validate();
 
+            SiaConfig conf = new SiaConfig();
             ParamExtractor pe = new ParamExtractor(SiaParamValidator.QUERY_PARAMS);
             Map<String, List<String>> queryParams = pe.getParameters(job.getParameterList());
 
             // Get the ADQL request parameters.
-            AdqlQueryGenerator queryGenerator = new AdqlQueryGenerator(queryParams);
+            AdqlQueryGenerator queryGenerator = new AdqlQueryGenerator(queryParams, conf.getTableName());
             Map<String, Object> parameters = queryGenerator.getParameterMap();
             parameters.put("FORMAT", VOTableWriter.CONTENT_TYPE);
             if (maxrec != null) {
@@ -175,7 +176,6 @@ public class SiaRunner implements JobRunner {
 
             // the implementation assumes that the /tap/sync service follows the 
             // POST-redirect-GET (PrG) pattern; cadcUWS SyncServlet does
-            SiaConfig conf = new SiaConfig();
             URL tapSyncURL = conf.getTapSyncURL();
 
             // POST ADQL query to TAP but do not follow redirect to execute it.

--- a/sia2/src/test/java/org/opencadc/sia2/AdqlQueryGeneratorTest.java
+++ b/sia2/src/test/java/org/opencadc/sia2/AdqlQueryGeneratorTest.java
@@ -108,7 +108,7 @@ public class AdqlQueryGeneratorTest {
 
         try {
             Map<String, List<String>> params = new TreeMap<String, List<String>>(new CaseInsensitiveStringComparator());
-            AdqlQueryGenerator gen = new AdqlQueryGenerator(params);
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "ivoa.ObsCore");
             Map<String, Object> tapParams = gen.getParameterMap();
 
             String lang = (String) tapParams.get("LANG");
@@ -132,7 +132,7 @@ public class AdqlQueryGeneratorTest {
             params.put("BAND", Arrays.asList("550e-9"));
             params.put("TIME", Arrays.asList("54321.0"));
 
-            AdqlQueryGenerator gen = new AdqlQueryGenerator(params);
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "ivoa.ObsCore");
             Map<String, Object> tapParams = gen.getParameterMap();
 
             String lang = (String) tapParams.get("LANG");
@@ -176,7 +176,7 @@ public class AdqlQueryGeneratorTest {
             params.put("SPECRP", Arrays.asList("-inf 500"));
             params.put("FORMAT", Arrays.asList("application/fits"));
 
-            AdqlQueryGenerator gen = new AdqlQueryGenerator(params);
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "ivoa.ObsCore");
             String adql = gen.getQuery();
             log.info("testSingleParams ADQL:\n" + adql);
 
@@ -233,7 +233,7 @@ public class AdqlQueryGeneratorTest {
             params.put("SPECRP", Arrays.asList("-Inf 500", "200 300"));
             params.put("FORMAT", Arrays.asList("application/fits", "text/xml"));
 
-            AdqlQueryGenerator gen = new AdqlQueryGenerator(params);
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "ivoa.ObsCore");
             String adql = gen.getQuery();
             log.info("testMultipleParams ADQL:\n" + adql);
 
@@ -273,10 +273,31 @@ public class AdqlQueryGeneratorTest {
             Map<String, List<String>> params = new TreeMap<String, List<String>>(new CaseInsensitiveStringComparator());
             params.put("POS", Arrays.asList("RANGE 0 360 -2 2", "RANGE 10 20 -90 90", "RANGE 1 2 3 4"));
 
-            AdqlQueryGenerator gen = new AdqlQueryGenerator(params);
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "ivoa.ObsCore");
             String adql = gen.getQuery();
             log.info("testCoordRanges ADQL:\n" + adql);
 
+            Assert.assertTrue("dataproduct_type", adql.contains("dataproduct_type"));
+            Assert.assertTrue("s_region", adql.contains("s_region"));
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testAltTableNames() {
+
+        try {
+            Map<String, List<String>> params = new TreeMap<String, List<String>>(new CaseInsensitiveStringComparator());
+            params.put("POS", Arrays.asList("RANGE 0 360 -2 2", "RANGE 10 20 -90 90", "RANGE 1 2 3 4"));
+
+            AdqlQueryGenerator gen = new AdqlQueryGenerator(params, "schema.TableName");
+            String adql = gen.getQuery();
+            log.info("testCoordRanges ADQL:\n" + adql);
+
+            String selectStmt = "SELECT * FROM schema.TableName WHERE";
+            Assert.assertTrue("schema.TableName", adql.contains(selectStmt));
             Assert.assertTrue("dataproduct_type", adql.contains("dataproduct_type"));
             Assert.assertTrue("s_region", adql.contains("s_region"));
         } catch (Exception unexpected) {


### PR DESCRIPTION
Allows for configuration of the ivoa.ObsCore table name from the properties file.

This allows us to configure multiple siav2 services to point at the same database / TAP service, each using a different table name.  We have this case at Rubin where each butler dataset has its own ObsCore table.